### PR TITLE
Introduce Zeit (now) auto deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Every package is available through NPM
 
 - [React components](packages/react/README.md)
 - [Standalone CSS](packages/css/README.md)
+- [How-to review new components](docs/how-to-review-new-components.md)
 
 ## License
 

--- a/docs/how-to-review-new-components.md
+++ b/docs/how-to-review-new-components.md
@@ -1,0 +1,7 @@
+
+## How-to review new components
+
+Each pull request will be automatically deploy on [Zeit](https://zeit.co) via `now`,
+producting a unique URL such as https://flamingo-git-gyndav-featzeit.heetch-eng.now.sh
+
+Each incremental changes will create a new slug.

--- a/now-build.sh
+++ b/now-build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Zeit (now for github)
+
+set -euo pipefail
+
+umask 077
+
+IFS=$'\n\t'
+
+# prerequisites
+yarn --cwd  packages/css install
+yarn --cwd packages/react install
+
+# build
+yarn --cwd packages/react run build:storybook

--- a/now.json
+++ b/now.json
@@ -1,0 +1,12 @@
+{
+  "name": "flamingo",
+  "version": 2,
+  "builds": [
+    {
+      "src": "now-build.sh",
+      "use": "@now/static-build",
+      "config": { "distDir": "packages/react/build" }
+    }
+  ],
+  "regions": ["cdg1", "dub1", "bru1", "lhr1"]
+}


### PR DESCRIPTION
## Business rationale
In order to ease reviewing when adding new components to Storybook, let's use **Zeit** in order to **automatically deploy each PR** on an isolated environment.

## Changes

* introduce Zeit `now`