### PR TITLE
Use box-shadow instead of border for Buttons

### DIFF
--- a/packages/css/src/components/Button.css
+++ b/packages/css/src/components/Button.css
@@ -60,7 +60,7 @@
 .f-Button.is-outline {
   background-color: var(--textColor);
   color: var(--mainBgColor);
-  border: 1px solid var(--mainBgColor);
+  box-shadow: 0 0 0 1px var(--mainBgColor);
 }
 
 .f-Button.is-minimal {


### PR DESCRIPTION
This is needed because using a `border` property makes the button larger than expected (40px vs 38px)