### PR TITLE
Export Selector and SelectorField to be available in the final build

### DIFF
--- a/packages/react/src/components/index.js
+++ b/packages/react/src/components/index.js
@@ -30,3 +30,5 @@ export { default as Toggle } from './Toggle';
 export { default as UiText } from './UiText';
 export { default as UploaderImageItem } from './UploaderImageItem';
 export { default as UploaderItem } from './UploaderItem';
+export { default as Selector } from './Selector';
+export { default as SelectorField } from './SelectorField';


### PR DESCRIPTION
The Selector and SelectorField were not being exported through the React's `index.js` and not available in the final build.