### PR TITLE
Fix engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "npm-run-all": "^4.1.5"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">= 12.x"
   },
   "precommit": "lerna run --concurrency 1 --stream precommit",
   "scripts": {

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/heetch/flamingo",
   "main": "./dist/index.css",
   "engines": {
-    "node": "12.x"
+    "node": ">= 12.x"
   },
   "files": [
     "dist"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,7 +9,7 @@
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
   "engines": {
-    "node": "12.x"
+    "node": ">= 12.x"
   },
   "scripts": {
     "test": "cross-env CI=1 react-scripts test --env=jsdom",


### PR DESCRIPTION
Set node v12.14.0 as the minimal required version, but also allow greater ones (13.x at the moment)