### PR TITLE
Accept uploads default value

### DIFF
--- a/packages/react/src/components/FileUploader/index.js
+++ b/packages/react/src/components/FileUploader/index.js
@@ -35,7 +35,6 @@ const FileUploader = React.forwardRef(
     {
       children,
       className,
-      files: filesProp,
       id,
       onChange,
       translate,
@@ -43,11 +42,12 @@ const FileUploader = React.forwardRef(
       hasError,
       multiple,
       overrides,
+      value,
       ...props
     },
     ref,
   ) => {
-    const [files, setFiles] = React.useState(filesProp);
+    const [files, setFiles] = React.useState(value);
     const hasFile = !isLoading && !hasError && files.length > 0;
 
     const handleFilesChange = e => {
@@ -66,10 +66,6 @@ const FileUploader = React.forwardRef(
       setFiles(remainingFiles);
       onChange(remainingFiles);
     };
-
-    React.useEffect(() => {
-      setFiles(filesProp);
-    }, [filesProp]);
 
     return (
       <div
@@ -165,26 +161,31 @@ FileUploader.propTypes = {
   id: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   translate: PropTypes.func,
-  files: PropTypes.arrayOf(PropTypes.instanceOf(File)),
   isLoading: PropTypes.bool,
   hasError: PropTypes.bool,
   multiple: PropTypes.bool,
   overrides: PropTypes.shape({
     input: PropTypes.shape({}),
   }),
+  value: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+    }),
+  ),
 };
 
 FileUploader.defaultProps = {
   children: undefined,
   className: undefined,
   translate: defaultTranslate,
-  files: [],
   hasError: false,
   isLoading: false,
   multiple: false,
   overrides: {
     input: {},
   },
+  value: [],
 };
 
 export default FileUploader;

--- a/packages/react/src/components/FileUploader/index.stories.js
+++ b/packages/react/src/components/FileUploader/index.stories.js
@@ -6,6 +6,16 @@ import { action } from '@storybook/addon-actions';
 import Heading from '../Heading';
 import FileUploader from '.';
 
+const stubFile1 = {
+  name: 'stub-file-1.txt',
+  type: 'text',
+};
+
+const stubFile2 = {
+  name: 'stub-file-2.txt',
+  type: 'text',
+};
+
 const stories = storiesOf('Form/FileUploader', module);
 
 stories.add('Playground', () => (
@@ -17,6 +27,26 @@ stories.add('Playground', () => (
       isLoading={boolean('Is loading', false)}
       hasError={boolean('Has error', false)}
       multiple={boolean('Has multiple files', true)}
+    />
+
+    <Heading level={2}>With default value</Heading>
+    <FileUploader
+      id='input-id'
+      onChange={action('onChange')}
+      isLoading={boolean('Is loading', false)}
+      hasError={boolean('Has error', false)}
+      multiple={false}
+      value={[stubFile1]}
+    />
+
+    <Heading level={2}>With default values</Heading>
+    <FileUploader
+      id='input-id'
+      onChange={action('onChange')}
+      isLoading={boolean('Is loading', false)}
+      hasError={boolean('Has error', false)}
+      multiple
+      value={[stubFile1, stubFile2]}
     />
   </>
 ));

--- a/packages/react/src/components/ImageUploader/index.js
+++ b/packages/react/src/components/ImageUploader/index.js
@@ -9,10 +9,14 @@ import UploaderImageItem from '../UploaderImageItem';
 
 import { toBase64 } from '../../utils';
 
+const getDefaultValuePreviews = files => files.map(file => file.preview);
+
 const ImageUploader = React.forwardRef(
-  ({ accept, className, multiple, onChange, ...props }, ref) => {
-    const [files, setFiles] = React.useState([]);
-    const [preview, setPreview] = React.useState(undefined);
+  ({ accept, className, multiple, onChange, value, ...props }, ref) => {
+    const [files, setFiles] = React.useState(value);
+    const [preview, setPreview] = React.useState(
+      getDefaultValuePreviews(value),
+    );
 
     const [isLoading, setIsLoading] = React.useState(false);
     const [hasError, setHasError] = React.useState(false);
@@ -55,7 +59,7 @@ const ImageUploader = React.forwardRef(
     return (
       <FileUploader
         className={cx('f-ImageUploader', className, {
-          'has-preview': preview,
+          'has-preview': !multiple && preview,
           'is-loading': isLoading,
         })}
         files={files}
@@ -67,9 +71,10 @@ const ImageUploader = React.forwardRef(
           input: { accept },
         }}
         ref={ref}
+        value={value}
         {...props}
       >
-        {preview && (
+        {!multiple && preview && (
           <>
             <div
               className='f-ImageUploader-preview'
@@ -105,12 +110,20 @@ ImageUploader.propTypes = {
   id: PropTypes.string.isRequired,
   multiple: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
+  value: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+      preview: PropTypes.string,
+    }),
+  ),
 };
 
 ImageUploader.defaultProps = {
   accept: 'image/*',
   className: undefined,
   multiple: false,
+  value: [],
 };
 
 export default ImageUploader;

--- a/packages/react/src/components/ImageUploader/index.stories.js
+++ b/packages/react/src/components/ImageUploader/index.stories.js
@@ -6,6 +6,18 @@ import { action } from '@storybook/addon-actions';
 import Heading from '../Heading';
 import ImageUploader from '.';
 
+const stubFile1 = {
+  name: 'image-stub-1',
+  type: 'image/jpg',
+  preview: 'https://api.adorable.io/avatars/285/10@adorable.io.png',
+};
+
+const stubFile2 = {
+  name: 'image-stub-2',
+  type: 'image/jpg',
+  preview: 'https://api.adorable.io/avatars/285/abott@adorable.png',
+};
+
 const stories = storiesOf('Form/ImageUploader', module);
 
 stories.add('Playground', () => (
@@ -15,6 +27,22 @@ stories.add('Playground', () => (
       id='input-id'
       onChange={action('onChange')}
       multiple={boolean('Has multiple files', true)}
+    />
+
+    <Heading level={2}>With default value</Heading>
+    <ImageUploader
+      id='input-default-value'
+      onChange={action('onChange')}
+      multiple={false}
+      value={[stubFile1]}
+    />
+
+    <Heading level={2}>With default values</Heading>
+    <ImageUploader
+      id='input-default-values'
+      onChange={action('onChange')}
+      multiple
+      value={[stubFile1, stubFile2]}
     />
   </>
 ));

--- a/packages/react/src/components/UploaderImageItem/index.js
+++ b/packages/react/src/components/UploaderImageItem/index.js
@@ -8,8 +8,8 @@ import { toBase64 } from '../../utils';
 
 const UploaderImageItem = React.forwardRef(
   ({ file, overrides, ...props }, ref) => {
-    const [preview, setPreview] = React.useState(undefined);
-    const [isLoading, setIsLoading] = React.useState(true);
+    const [preview, setPreview] = React.useState(file.preview);
+    const [isLoading, setIsLoading] = React.useState(!file.preview);
 
     const icon = isLoading ? (
       <Spinner />
@@ -18,6 +18,10 @@ const UploaderImageItem = React.forwardRef(
     );
 
     React.useEffect(() => {
+      if (file.preview) {
+        return;
+      }
+
       toBase64(file).then(base64 => {
         setPreview(base64);
         setIsLoading(false);
@@ -38,7 +42,11 @@ const UploaderImageItem = React.forwardRef(
 UploaderImageItem.displayName = 'UploaderImageItem';
 
 UploaderImageItem.propTypes = {
-  file: PropTypes.instanceOf(File).isRequired,
+  file: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    preview: PropTypes.string,
+  }).isRequired,
   overrides: PropTypes.shape({}),
 };
 

--- a/packages/react/src/components/UploaderItem/index.js
+++ b/packages/react/src/components/UploaderItem/index.js
@@ -30,7 +30,10 @@ UploaderItem.displayName = 'UploaderItem';
 
 UploaderItem.propTypes = {
   className: PropTypes.string,
-  file: PropTypes.instanceOf(File).isRequired,
+  file: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+  }).isRequired,
   handleDelete: PropTypes.func.isRequired,
   overrides: PropTypes.shape({
     icon: PropTypes.node,


### PR DESCRIPTION
Allow passing a default `value` props for each type of uploaders
The value must be an `Array` of file-like items

For `FileUploader`, a back-end could send a file-like structure via JSON 
```
const stubFile1 = {
  name: 'stub-file-1.txt',
  type: 'text',
};
```

Same for an `ImageUploader`, while including the file URL into a `preview` entry
```
const stubFile1 = {
  name: 'image-stub-1',
  type: 'image/jpg',
  preview: 'https://api.adorable.io/avatars/285/10@adorable.io.png',
};
```

Bonus: it will fix https://github.com/heetch/flamingo/issues/76