### PR TITLE
Add a `header` prop to SidePanel, to use Components in it

### DIFF
--- a/packages/react/src/components/SidePanel/index.js
+++ b/packages/react/src/components/SidePanel/index.js
@@ -14,6 +14,7 @@ const SidePanel = ({
   isOpen: isOpenProp,
   onClose,
   title,
+  header,
   ...props
 }) => {
   const [isOpen, setIsOpen] = React.useState(isOpenProp);
@@ -51,9 +52,11 @@ const SidePanel = ({
         {...props}
       >
         <div className='f-SidePanel-header'>
-          <Heading level={4} as='h1'>
-            {title}
-          </Heading>
+          {header || (
+            <Heading level={4} as='h1'>
+              {title}
+            </Heading>
+          )}
 
           <IconButton icon={IconButton.ICONS.IconCross} onClick={handleClose} />
         </div>
@@ -75,6 +78,7 @@ SidePanel.propTypes = {
   isOpen: PropTypes.bool,
   onClose: PropTypes.func,
   title: PropTypes.node,
+  header: PropTypes.node,
 };
 
 SidePanel.defaultProps = {
@@ -85,6 +89,7 @@ SidePanel.defaultProps = {
   isOpen: false,
   onClose: () => {},
   title: undefined,
+  header: undefined,
 };
 
 export default SidePanel;

--- a/packages/react/src/components/SidePanel/index.stories.js
+++ b/packages/react/src/components/SidePanel/index.stories.js
@@ -15,6 +15,8 @@ stories.add('Playground', () => {
   const closesOnOverlayClick = boolean('closesOnOverlayClick?', true);
   const withLargeContent = boolean('With large content?', false);
   const withFooter = boolean('With footer?', true);
+  const withHeader = boolean('With header?', false);
+  const withTitle = !withHeader && text('Title', 'Side Panel Title');
 
   const content = (
     <>
@@ -29,7 +31,20 @@ stories.add('Playground', () => {
 
       <SidePanel
         closesOnOverlayClick={closesOnOverlayClick}
-        title={text('Title', 'Side Panel Title')}
+        title={withTitle}
+        header={
+          withHeader && (
+            <>
+              <Button
+                intent={Button.INTENTS.SECONDARY}
+                variant={Button.VARIANTS.MINIMAL}
+              >
+                Select all
+              </Button>
+              <Button>Never gonna let you down</Button>
+            </>
+          )
+        }
         footer={
           withFooter && (
             <>


### PR DESCRIPTION
- Add a `header` prop to SidePanel, to use Components in it

For a new feature in the admin, we need to be able to send React components to the `side panel` header the way we do it for the footer.