### PR TITLE
Add back the div containing the header

### DIFF
--- a/packages/react/src/components/SidePanel/index.js
+++ b/packages/react/src/components/SidePanel/index.js
@@ -52,7 +52,9 @@ const SidePanel = ({
         {...props}
       >
         <div className='f-SidePanel-header'>
-          {header || (
+          {header ? (
+            <div className='f-SidePanel-headerContent'>{header}</div>
+          ) : (
             <Heading level={4} as='h1'>
               {title}
             </Heading>


### PR DESCRIPTION
I had added an empty div containing the header but removed it. I need to add it back, because the header has styles with `justify-content: space-inbetween`, which makes any component inside of it have a lot of space and not behave like you'd expect it.