### PR TITLE
Dropdown/improvements

### DIFF
--- a/packages/css/src/components/Dropdown.css
+++ b/packages/css/src/components/Dropdown.css
@@ -10,6 +10,7 @@
   /* --f-breakpoint--s */
   /* !important are needed to override inline styles */
   .f-DropdownList {
+    position: fixed !important;
     top: 50% !important;
     left: var(--f-space--xl) !important;
     right: var(--f-space--xl) !important;

--- a/packages/css/src/components/Dropdown.css
+++ b/packages/css/src/components/Dropdown.css
@@ -6,11 +6,6 @@
   z-index: calc(var(--f-zIndex--Overlay) + 1);
 }
 
-.f-DropdownList.is-hidden {
-  opacity: 0;
-  pointer-events: none;
-}
-
 @media (max-width: 460px) {
   /* --f-breakpoint--s */
   /* !important are needed to override inline styles */

--- a/packages/react/src/components/Dropdown/index.js
+++ b/packages/react/src/components/Dropdown/index.js
@@ -8,6 +8,8 @@ const Dropdown = ({
   children,
   clickOutsideToHide,
   isOpen: isOpenProp,
+  onHide,
+  onOpen,
   triggerer,
   placement,
 }) => {
@@ -21,6 +23,11 @@ const Dropdown = ({
   const [refNode, setRefNode] = React.useState();
 
   const renderFnProps = { isOpen, open, hide, toggle };
+
+  React.useEffect(() => {
+    if (isOpen) onOpen();
+    else onHide();
+  }, [isOpen, onHide, onOpen]);
 
   React.useEffect(() => {
     const onDocumentClick = ({ target }) => {
@@ -79,6 +86,8 @@ Dropdown.propTypes = {
   children: PropTypes.func.isRequired,
   clickOutsideToHide: PropTypes.bool,
   isOpen: PropTypes.bool,
+  onHide: PropTypes.func,
+  onOpen: PropTypes.func,
   triggerer: PropTypes.func.isRequired,
   placement: PropTypes.string, // https://popper.js.org/docs/v1/#Popper.placements
 };
@@ -86,6 +95,8 @@ Dropdown.propTypes = {
 Dropdown.defaultProps = {
   clickOutsideToHide: true,
   isOpen: false,
+  onHide: () => {},
+  onOpen: () => {},
   placement: 'bottom-end',
 };
 

--- a/packages/react/src/components/Dropdown/index.js
+++ b/packages/react/src/components/Dropdown/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 import { Manager, Reference, Popper } from 'react-popper';
 
 import Overlay from '../Overlay';
@@ -53,20 +52,22 @@ const Dropdown = ({
         innerRef={setPopperNode}
         placement={placement}
       >
-        {({ ref, style }) => (
-          <>
-            <div
-              className={cx('f-DropdownList', { 'is-hidden': !isOpen })}
-              ref={ref}
-              style={style}
-              data-placement={placement}
-            >
-              {children(renderFnProps)}
-            </div>
+        {({ ref, style }) =>
+          isOpen && (
+            <>
+              <div
+                className='f-DropdownList'
+                ref={ref}
+                style={style}
+                data-placement={placement}
+              >
+                {children(renderFnProps)}
+              </div>
 
-            {isOpen && <Overlay className='f-DropdownOverlay' />}
-          </>
-        )}
+              <Overlay className='f-DropdownOverlay' />
+            </>
+          )
+        }
       </Popper>
     </Manager>
   );

--- a/packages/react/src/components/Dropdown/index.stories.js
+++ b/packages/react/src/components/Dropdown/index.stories.js
@@ -25,6 +25,8 @@ stories.add('Playground', () => (
       }}
     >
       <Dropdown
+        onHide={action('onHide')}
+        onOpen={action('onOpen')}
         isOpen
         triggerer={({ ref, toggle }) => (
           <Button ref={ref} onClick={toggle}>


### PR DESCRIPTION
#### Do not render list when hidden
This is actually needed when used in a form context because the list will be rendered between the form element used as a reference (most likely an input) and the helper, causing the helper not inheriting of the valid/invalid styles
And IMO it's also better to not render stuff if not needed 🙂 

#### List should be fixed on mobile
Needed to avoid having the list moving with the page scroll, leading to only display the overlay