### PR TITLE
Enable manual sorting for table

### DIFF
--- a/packages/react/src/components/Table/index.js
+++ b/packages/react/src/components/Table/index.js
@@ -9,11 +9,20 @@ import RowGroup from '../TableRowGroup';
 import RowCell from '../TableRowCell';
 
 const Table = React.forwardRef(
-  ({ className, columns, data, isSortable }, ref) => {
-    const { headerGroups, rows, prepareRow } = useTable(
+  (
+    { className, columns, data, isSortable, manualSorting, onChangeSort },
+    ref,
+  ) => {
+    const {
+      headerGroups,
+      rows,
+      prepareRow,
+      state: { sortBy },
+    } = useTable(
       {
         columns,
         data,
+        manualSorting,
       },
       useSortBy,
     );
@@ -25,6 +34,10 @@ const Table = React.forwardRef(
         }),
       [prepareRow, rows],
     );
+
+    React.useEffect(() => {
+      onChangeSort(sortBy);
+    }, [onChangeSort, sortBy]);
 
     return (
       <table
@@ -84,6 +97,8 @@ Table.propTypes = {
   ),
   data: PropTypes.arrayOf(PropTypes.shape({})),
   isSortable: PropTypes.bool,
+  manualSorting: PropTypes.bool,
+  onChangeSort: PropTypes.func,
 };
 
 Table.defaultProps = {
@@ -91,6 +106,8 @@ Table.defaultProps = {
   columns: [],
   data: [],
   isSortable: false,
+  onChangeSort: () => {},
+  manualSorting: false,
 };
 
 Table.HeaderGroup = HeaderGroup;

--- a/packages/react/src/components/Table/index.stories.js
+++ b/packages/react/src/components/Table/index.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 import Heading from '../Heading';
 import Icon from '../Icon';
@@ -37,6 +38,30 @@ stories.add('Playground', () => (
       ]}
       data={data}
       isSortable={boolean('Is sortable', false)}
+    />
+
+    <Heading>Table with manual sorting</Heading>
+    <Table
+      columns={[
+        {
+          Header: text("Col #1's heading", 'With string'),
+          accessor: 'string',
+        },
+        {
+          Header: text("Col #2's heading", 'With number'),
+          accessor: 'number',
+          Cell: item => <Text isNumber>{item.cell.value}</Text>,
+        },
+        {
+          Header: text("Col #3's heading", 'With custom rendering'),
+          accessor: 'custom',
+          Cell: () => <Icon icon={Icon.ICONS.IconMoon} />,
+        },
+      ]}
+      data={data}
+      isSortable={boolean('Is sortable', false)}
+      manualSorting
+      onChangeSort={action('onChangeSort')}
     />
   </>
 ));


### PR DESCRIPTION
This PR adds two props to the `Table` component to allow the sorting to be done externally (like on the backend)

- `manualSorting` - to disable the client-side sorting that react-table does, but still keep the state/styling 
- `onChangeSort` - a function which receives the sorted state e.g. `{ desc: false, id: "name" }`