### PR TITLE
Update rollup config for react-day-picker

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -25,7 +25,9 @@ export default {
   plugins: [
     external(),
     postcss({
-      modules: true,
+      modules: {
+        globalModulePaths: [/node_modules\/react-day-picker/],
+      },
     }),
     url(),
     svgr(),


### PR DESCRIPTION
This change prevents `import 'react-day-picker/lib/style.css'` from being transformed to CSS modules by postcss. This fixes the display of the `Datepicker` component when it's used externally. 

I compared a diff of the dist/index.js and dist/index.es.js files before and after this change, and the only difference is that the styles of the datepicker don't have scoped selectors anymore. 