### PR TITLE
System font fix

### DIFF
--- a/packages/css/src/shared/global.css
+++ b/packages/css/src/shared/global.css
@@ -3,8 +3,8 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  font-family: -apple-system, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+    'Helvetica Neue', sans-serif;
   line-height: var(--f-lineHeight--m);
 }
 


### PR DESCRIPTION
Removed the system font `BlinkMacSystemFont` which was not showing bolded header components in latest webkit browsers.