### PR TITLE
Remove Vercel regions as not part of Hobby plan

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,4 +1,3 @@
 {
-  "version": 2,
-  "regions": ["cdg1", "dub1", "bru1", "lhr1"]
+  "version": 2
 }


### PR DESCRIPTION
```
Deployment failed with the following error:
Deploying Serverless Functions to multiple regions is restricted to the Enterprise plan for Teams.
```

Indeed, [Hobby plan](https://vercel.com/docs/configuration#project/regions) doesn't have it anymore.