### PR TITLE
Make component propTypes SSR friendly

### DIFF
--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -105,7 +105,9 @@ Dropdown.propTypes = {
   onOpen: PropTypes.func,
   triggerer: PropTypes.func.isRequired,
   placement: PropTypes.string, // https://popper.js.org/docs/v1/#Popper.placements
-  portalNode: PropTypes.instanceOf(HTMLElement),
+  portalNode: PropTypes.instanceOf(
+    typeof HTMLElement !== 'undefined' ? HTMLElement : Object,
+  ),
   modifiers: PropTypes.shape({}), // https://popper.js.org/docs/v1/#modifiers
 };
 

--- a/src/components/InputField/index.js
+++ b/src/components/InputField/index.js
@@ -17,7 +17,9 @@ InputField.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.node,
   inputRef: PropTypes.shape({
-    current: PropTypes.instanceOf(Element),
+    current: PropTypes.instanceOf(
+      typeof Element !== 'undefined' ? Element : Object,
+    ),
   }),
 };
 

--- a/src/components/SelectField/index.js
+++ b/src/components/SelectField/index.js
@@ -17,7 +17,9 @@ SelectField.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.node,
   selectRef: PropTypes.shape({
-    current: PropTypes.instanceOf(Element),
+    current: PropTypes.instanceOf(
+      typeof Element !== 'undefined' ? Element : Object,
+    ),
   }),
 };
 

--- a/src/components/SelectorField/index.js
+++ b/src/components/SelectorField/index.js
@@ -17,7 +17,9 @@ SelectorField.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.node,
   selectorRef: PropTypes.shape({
-    current: PropTypes.instanceOf(Element),
+    current: PropTypes.instanceOf(
+      typeof Element !== 'undefined' ? Element : Object,
+    ),
   }),
 };
 

--- a/src/components/TextareaField/index.js
+++ b/src/components/TextareaField/index.js
@@ -17,7 +17,9 @@ TextareaField.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.node,
   inputRef: PropTypes.shape({
-    current: PropTypes.instanceOf(Element),
+    current: PropTypes.instanceOf(
+      typeof Element !== 'undefined' ? Element : Object,
+    ),
   }),
 };
 

--- a/src/components/UploaderField/index.js
+++ b/src/components/UploaderField/index.js
@@ -17,7 +17,9 @@ UploaderField.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.node,
   inputRef: PropTypes.shape({
-    current: PropTypes.instanceOf(Element),
+    current: PropTypes.instanceOf(
+      typeof Element !== 'undefined' ? Element : Object,
+    ),
   }),
 };
 

--- a/src/components/_DeprecatedFileUploaderField/index.js
+++ b/src/components/_DeprecatedFileUploaderField/index.js
@@ -26,7 +26,9 @@ FileUploaderField.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.node,
   inputRef: PropTypes.shape({
-    current: PropTypes.instanceOf(Element),
+    current: PropTypes.instanceOf(
+      typeof Element !== 'undefined' ? Element : Object,
+    ),
   }),
 };
 

--- a/src/components/_DeprecatedImageUploaderField/index.js
+++ b/src/components/_DeprecatedImageUploaderField/index.js
@@ -26,7 +26,9 @@ ImageUploaderField.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.node,
   inputRef: PropTypes.shape({
-    current: PropTypes.instanceOf(Element),
+    current: PropTypes.instanceOf(
+      typeof Element !== 'undefined' ? Element : Object,
+    ),
   }),
 };
 


### PR DESCRIPTION
By adding a small check for proptypes that refer to `HTMLElement` or `Element` these components would be safe to use with SSR