### PR TITLE
Allow string or Date for Datepicker

### DIFF
--- a/src/components/Datepicker/index.js
+++ b/src/components/Datepicker/index.js
@@ -61,7 +61,10 @@ Datepicker.propTypes = {
   invalid: PropTypes.bool,
   valid: PropTypes.bool,
   placeholder: PropTypes.string,
-  value: PropTypes.instanceOf(Date),
+  value: PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.instanceOf(Date),
+]),
   onChange: PropTypes.func,
   formatDate: PropTypes.func,
   renderNavigation: PropTypes.func,


### PR DESCRIPTION
Right now we can pass a String but we get a proptype error in console