### PR TITLE
2.3.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.5.1",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "packages": [
     "./"
   ]

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.5.1",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "packages": [
     "./"
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heetch/flamingo-react",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Heetch Web Design System - Styled Components based",
   "author": "Heetch",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heetch/flamingo-react",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Heetch Web Design System - Styled Components based",
   "author": "Heetch",
   "license": "MIT",


### PR DESCRIPTION
PR to bump the release version - this was a mistake as it should have been done in the previous PR.

I deleted the previous tag 2.3.0 (which was created by mistake) on github, then fetched new tags locally - however could not delete the ref made to the previous tag (2.3.0) through lerna so had to bump the version to 2.3.1.

I will add publish notes in the readme section to avoid any issues like this going forwards.