### PR TITLE
Allow onClick event for table rows

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -17,6 +17,7 @@ const Table = React.forwardRef(
       manualSorting,
       onChangeSort,
       initialState,
+      onClickRow,
     },
     ref,
   ) => {
@@ -83,7 +84,11 @@ const Table = React.forwardRef(
 
         <tbody>
           {rows.map(row => (
-            <tr className={'f-Table-RowGroup'} {...row.getRowProps()}>
+            <tr
+              className={'f-Table-RowGroup'}
+              {...row.getRowProps()}
+              onClick={() => onClickRow(row.original)}
+            >
               {row.cells.map(({ getCellProps, render }) => (
                 <RowCell {...getCellProps()}>{render('Cell')}</RowCell>
               ))}
@@ -109,6 +114,7 @@ Table.propTypes = {
   isSortable: PropTypes.bool,
   manualSorting: PropTypes.bool,
   onChangeSort: PropTypes.func,
+  onClickRow: PropTypes.func,
   initialState: PropTypes.shape({
     sortBy: PropTypes.arrayOf(
       PropTypes.shape({
@@ -123,6 +129,7 @@ Table.defaultProps = {
   columns: [],
   data: [],
   onChangeSort: () => {},
+  onClickRow: () => {},
 };
 
 Table.HeaderCell = HeaderCell;

--- a/src/components/Table/index.stories.js
+++ b/src/components/Table/index.stories.js
@@ -5,8 +5,10 @@ import { action } from '@storybook/addon-actions';
 
 import Heading from '../Heading';
 import Icon from '../Icon';
+import IconButton from '../IconButton';
 import Table from '.';
 import Text from '../Text';
+import Link from '../Link';
 
 const stories = storiesOf('Tables/Table', module);
 
@@ -48,6 +50,31 @@ stories.add('All states', () => (
       manualSorting
       initialState={{ sortBy: [{ id: 'number', desc: true }] }}
     />
+
+    <Heading level={2}>With clickable rows</Heading>
+    <Table
+      {...defaultProps}
+      columns={[
+        ...defaultProps.columns,
+        {
+          Header: text("Col #4's heading", 'With a link and button'),
+          accessor: null,
+          Cell: () => (
+            <>
+              <Link href='#link'>Click me</Link>
+              <IconButton
+                icon={Icon.ICONS.IconOption}
+                onClick={e => {
+                  e.stopPropagation();
+                  action('onClickIconButton')(e);
+                }}
+              />
+            </>
+          ),
+        },
+      ]}
+      onClickRow={action('onClickRow')}
+    />
   </>
 ));
 
@@ -59,6 +86,7 @@ stories.add('Playground', () => (
       isSortable={boolean('Table 1 sortable', false)}
       manualSorting={boolean('manualSorting')}
       onChangeSort={action('onChangeSort')}
+      onClickRow={action('onClickRow')}
       initialState={{ sortBy: [{ id: 'number', desc: true }] }}
     />
   </>

--- a/src/components/Textarea/index.stories.js
+++ b/src/components/Textarea/index.stories.js
@@ -10,6 +10,7 @@ const states = ['default', 'disabled'];
 
 const textareaProps = () => ({
   id: `textarea-${Math.random()}`,
+  // eslint-disable-next-line no-console
   onChange: console.log,
 });
 


### PR DESCRIPTION
This PR adds the prop `onClickRow` to the `Table` component. When a row is clicked, the original data values will be passed to the handler. E.g.

```javascript
const data = [
  { name: 'Tam', active: true },
  { name: 'Paco', active: false },
];

return (
  <Table
    data={data}
    columns={[
      {
        Header: 'Name',
        accessor: 'name',
      },
      {
        Header: 'Name',
        accessor: 'name',
      },
    ]}
    onClickRow={row => console.log(row)} //outputs { name: X, active: X }
  />
);

```