### PR TITLE
Update Table proptypes for accessor

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -107,7 +107,7 @@ Table.propTypes = {
   columns: PropTypes.arrayOf(
     PropTypes.shape({
       Header: PropTypes.string,
-      accessor: PropTypes.string,
+      accessor: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     }),
   ),
   data: PropTypes.arrayOf(PropTypes.shape({})),


### PR DESCRIPTION
This PR updates the prop type definitions for the Table component to remove the error messages when we have a valid definition of `accessor` as a function 