### PR TITLE
Add custom key feature to Tabs

### DIFF
--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -15,6 +15,7 @@ const Tabs = React.forwardRef(
       defaultIndex,
       buildTabLabel,
       buildReturnObject,
+      buildKey,
       onClick,
       ...props
     },
@@ -39,7 +40,7 @@ const Tabs = React.forwardRef(
         <StyledTabs className='f-Tabs'>
           {elements.map((element, index) => (
             <Tab
-              key={element}
+              key={buildKey ? buildKey(element) : element}
               type='button'
               onClick={() => handleTabClick(index)}
               onKeyPress={({ key }) =>
@@ -70,10 +71,12 @@ Tabs.propTypes = {
   ).isRequired,
   /** This allows changing the tab that should be open on initial render. */
   defaultIndex: PropTypes.number,
-  /** If objects passed to elements, this should be a method that extracts a label string from the obejct */
+  /** If objects passed to elements, this should be a method that extracts a label string from the object */
   buildTabLabel: PropTypes.func,
   /** If objects passed to elements, this should be a method that extracts a value to be returned to onClick */
   buildReturnObject: PropTypes.func,
+  /** If objects passed to elements, this should be a method that extracts a key to identify the object */
+  buildKey: PropTypes.func,
   onClick: PropTypes.func,
 };
 

--- a/src/components/Tabs/index.stories.js
+++ b/src/components/Tabs/index.stories.js
@@ -42,6 +42,7 @@ stories.add('All states', () => (
       ]}
       buildTabLabel={e => e.label}
       buildReturnObject={e => e.value}
+      buildKey={e => e.value}
       onClick={action('Click')}
     />
     <Code>{`
@@ -52,6 +53,7 @@ stories.add('All states', () => (
       ]}
       buildTabLabel={e => e.label}
       buildReturnObject={e => e.value}
+      buildKey={e => e.value}
       onClick={noop}
     />
     `}</Code>


### PR DESCRIPTION
When using objects as elements for `<Tabs />`, React was displaying an error because the component used the object itself as a key. This PR adds a `buildKey` function prop to allow the caller to specify how to build a key for each element.