### PR TITLE
Make Toggle stateless

### DIFF
--- a/src/components/Toggle/index.js
+++ b/src/components/Toggle/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
@@ -6,10 +6,10 @@ import Helper from '../Helper';
 import {
   StyledToggle,
   ToggleBullet,
-  ToggleBulletLabelOn,
   ToggleBulletLabelOff,
-  ToggleLabels,
+  ToggleBulletLabelOn,
   ToggleContainer,
+  ToggleLabels,
 } from './styles';
 
 const Toggle = React.forwardRef(
@@ -17,15 +17,12 @@ const Toggle = React.forwardRef(
     { children, className, checked, disabled, helper, onChange, ...props },
     ref,
   ) => {
-    const [isOn, setIsOn] = useState(checked);
-
     const handleToggle = () => {
       if (disabled) {
         return;
       }
 
-      setIsOn(!isOn);
-      onChange(!isOn);
+      onChange(!checked);
     };
 
     const labelProps = {
@@ -43,25 +40,25 @@ const Toggle = React.forwardRef(
           className='f-Toggle'
           {...labelProps}
           disabled={disabled}
-          isOn={isOn}
+          isOn={checked}
           type='button'
         >
           <ToggleBullet
             className='f-Toggle-bullet'
             disabled={disabled}
-            isOn={isOn}
+            isOn={checked}
           />
           <ToggleBulletLabelOn
             className='f-Toggle-bullet-label f-Toggle-bullet-label--on'
             disabled={disabled}
-            isOn={isOn}
+            isOn={checked}
           >
             ON
           </ToggleBulletLabelOn>
           <ToggleBulletLabelOff
             className='f-Toggle-bullet-label f-Toggle-bullet-label--off'
             disabled={disabled}
-            isOn={isOn}
+            isOn={checked}
           >
             OFF
           </ToggleBulletLabelOff>

--- a/src/components/Toggle/index.stories.js
+++ b/src/components/Toggle/index.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
@@ -64,19 +64,35 @@ stories.add('All states', () => (
         </Toggle>
       </div>
     </div>
-    <Code>{`
+    <Code>{` 
     <Toggle name='no-text' onChange={noop} />
     <Toggle name='with-helper' helper='With texts'>Label</Toggle>
     `}</Code>
   </>
 ));
 
-stories.add('Playground', () => (
-  <Toggle
-    disabled={boolean('Is disabled?', false)}
-    helper={text('Label helper', 'Label helper')}
-    onChange={action('onChange')}
-  >
-    {text('Label', 'Toggle label')}
-  </Toggle>
-));
+stories.add('Playground', () => {
+  const [isChecked, setIsChecked] = useState(false);
+  const onChangeAction = action('onChange');
+
+  const onChange = state => {
+    onChangeAction(state);
+    setIsChecked(state);
+  };
+
+  return (
+    <>
+      <Toggle
+        disabled={boolean('Is disabled?', false)}
+        helper={text('Label helper', 'Label helper')}
+        onChange={onChange}
+        checked={isChecked}
+      >
+        {text('Label', 'Toggle label')}
+      </Toggle>
+
+      <button onClick={() => setIsChecked(true)}>Force ON</button>
+      <button onClick={() => setIsChecked(false)}>Force OFF</button>
+    </>
+  );
+});


### PR DESCRIPTION
This PR changes the `Toggle` component so it is stateless. This allows to control its state from outside, by updating the `checked` prop; which was not possible before. 

This implies the caller has the responsibility to hold the state.