### PR TITLE
Make Toggle statefull again, but responding to `checked` changes

### DIFF
--- a/src/components/Toggle/index.js
+++ b/src/components/Toggle/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
@@ -17,12 +17,19 @@ const Toggle = React.forwardRef(
     { children, className, checked, disabled, helper, onChange, ...props },
     ref,
   ) => {
+    const [isOn, setIsOn] = useState(checked);
+
+    useEffect(() => {
+      setIsOn(checked);
+    }, [checked]);
+
     const handleToggle = () => {
       if (disabled) {
         return;
       }
 
-      onChange(!checked);
+      setIsOn(!isOn);
+      onChange(!isOn);
     };
 
     const labelProps = {
@@ -40,25 +47,25 @@ const Toggle = React.forwardRef(
           className='f-Toggle'
           {...labelProps}
           disabled={disabled}
-          isOn={checked}
+          isOn={isOn}
           type='button'
         >
           <ToggleBullet
             className='f-Toggle-bullet'
             disabled={disabled}
-            isOn={checked}
+            isOn={isOn}
           />
           <ToggleBulletLabelOn
             className='f-Toggle-bullet-label f-Toggle-bullet-label--on'
             disabled={disabled}
-            isOn={checked}
+            isOn={isOn}
           >
             ON
           </ToggleBulletLabelOn>
           <ToggleBulletLabelOff
             className='f-Toggle-bullet-label f-Toggle-bullet-label--off'
             disabled={disabled}
-            isOn={checked}
+            isOn={isOn}
           >
             OFF
           </ToggleBulletLabelOff>

--- a/src/components/Toggle/index.stories.js
+++ b/src/components/Toggle/index.stories.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { boolean, text } from '@storybook/addon-knobs';
+import { boolean, number, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import { theme } from '../../theme';
@@ -64,7 +64,7 @@ stories.add('All states', () => (
         </Toggle>
       </div>
     </div>
-    <Code>{` 
+    <Code>{`
     <Toggle name='no-text' onChange={noop} />
     <Toggle name='with-helper' helper='With texts'>Label</Toggle>
     `}</Code>
@@ -74,10 +74,13 @@ stories.add('All states', () => (
 stories.add('Playground', () => {
   const [isChecked, setIsChecked] = useState(false);
   const onChangeAction = action('onChange');
+  const delay = number('Update delay (ms)', 500);
 
   const onChange = state => {
-    onChangeAction(state);
-    setIsChecked(state);
+    setTimeout(() => {
+      onChangeAction(state);
+      setIsChecked(state);
+    }, delay);
   };
 
   return (


### PR DESCRIPTION
The previous change made Toggle feel unresponsive if the external state was updated with a delay (for instance based on a network call). 
To fix this UX problem, this PR brings back the internal state of Toggle, but makes it responsive to subsequent changes of the `checked` prop. 

To illustrate this, the Playground in Storybook introduces a delay in the external state update (visible by the _action_ logging with a delay) but the Toggle's UI is updated as soon as the user clicks.