### PR TITLE
Uploader - Icon always visible

### DIFF
--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Icon from '../Icon';
-import IconButton from '../IconButton';
 import Spinner from '../Spinner';
 import UploaderImageItem from '../UploaderImageItem';
 import UploaderItem from '../UploaderItem';
@@ -144,11 +143,7 @@ const Uploader = React.forwardRef(
         {state === STATES.SINGLE_IMAGE && (
           <>
             <Preview preview={preview} />
-            <TrashButton
-              onClick={onClear}
-              icon={IconButton.ICONS.IconTrash}
-              iconColor={iconColor}
-            />
+            <TrashButton onClick={onClear} iconColor={iconColor} />
             <PreviewActions />
           </>
         )}

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -8,7 +8,13 @@ import UploaderImageItem from '../UploaderImageItem';
 import UploaderItem from '../UploaderItem';
 
 import State from './State';
-import { Container, InputContainer, Preview, PreviewActions } from './styles';
+import {
+  Container,
+  InputContainer,
+  Preview,
+  PreviewActions,
+  TrashButton,
+} from './styles';
 import { STATES } from './constants';
 
 import { toBase64 } from '../../utils';
@@ -38,6 +44,7 @@ const Uploader = React.forwardRef(
   (
     {
       id,
+      iconColor,
       invalid,
       onChange,
       translate,
@@ -137,9 +144,12 @@ const Uploader = React.forwardRef(
         {state === STATES.SINGLE_IMAGE && (
           <>
             <Preview preview={preview} />
-            <PreviewActions>
-              <IconButton onClick={onClear} icon={IconButton.ICONS.IconTrash} />
-            </PreviewActions>
+            <TrashButton
+              onClick={onClear}
+              icon={IconButton.ICONS.IconTrash}
+              iconColor={iconColor}
+            />
+            <PreviewActions />
           </>
         )}
 
@@ -190,6 +200,7 @@ Uploader.displayName = 'Uploader';
 
 Uploader.propTypes = {
   id: PropTypes.string.isRequired,
+  iconColor: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   translate: PropTypes.func,
   invalid: PropTypes.bool,

--- a/src/components/Uploader/index.stories.js
+++ b/src/components/Uploader/index.stories.js
@@ -35,9 +35,9 @@ const stories = storiesOf('Form/Uploader', module);
 stories.add('All states', () => (
   <>
     <Heading>Uploader</Heading>
-    <Uploader id='uploader' onChange={noop} />
+    <Uploader id='uploader' onChange={noop} iconColor='orange' />
     <Code>{`
-    <Uploader onChange={noop} />
+    <Uploader onChange={noop}  iconColor='orange' />
     `}</Code>
 
     <Heading level={2}>With default value</Heading>

--- a/src/components/Uploader/styles.js
+++ b/src/components/Uploader/styles.js
@@ -85,7 +85,9 @@ export const PreviewActions = styled.div`
   z-index: 15;
 `;
 
-export const TrashButton = styled(IconButton)`
+export const TrashButton = styled(IconButton).attrs({
+  icon: IconButton.ICONS.IconTrash,
+})`
   z-index: 20;
   margin: ${theme.space.m};
   align-self: end;

--- a/src/components/Uploader/styles.js
+++ b/src/components/Uploader/styles.js
@@ -2,6 +2,7 @@ import styled from 'styled-components/macro';
 import FormElementWrapper from '../FormComponents/FormElementWrapper';
 import Icon from '../Icon';
 import UiText from '../UiText';
+import IconButton from '../IconButton';
 
 import { theme } from '../../theme';
 import { STATES } from './constants';
@@ -79,12 +80,20 @@ export const PreviewActions = styled.div`
   bottom: -1px;
   border-radius: ${theme.borderRadius.s};
   background: ${theme.color.element.overlay};
-  padding: 0 ${theme.space.m};
-  text-align: right;
-  opacity: 0;
   pointer-events: none;
+  opacity: 0;
   z-index: 15;
-  transition: opacity 0.1s ease-out;
+`;
+
+export const TrashButton = styled(IconButton)`
+  z-index: 20;
+  margin: ${theme.space.m};
+  align-self: end;
+  padding: ${theme.space.s} !important;
+  background-color: #ffffff !important;
+  * {
+    color: ${({ iconColor }) => iconColor || theme.color_v3.feedback.error};
+  }
 `;
 
 export const Container = styled(FormElementWrapper)`
@@ -96,7 +105,6 @@ export const Container = styled(FormElementWrapper)`
   border-radius: ${theme.borderRadius.s};
   color: ${styles.textColor};
   background-color: ${theme.color.element.primary};
-  transition: all 0.15s ease-out;
   border: 1px dashed ${styles.borderColor};
 
   &:hover {


### PR DESCRIPTION
Linked to [DAB-1169] & Pierre Lange's comment. 

Having the `IconButton` with an unset color on the Uploader is not good UX. 
We don't know that we have to go to the top right of the image uploaded, to actually see the icon, and delete the file. 

I've changed the color, to make it always visible when the file is uploaded. 

UPDATE : I've put the default color in RED (After Pierre's discussions)  - to be aligned between passenger / driver colors  + IconColor can be chosen :) 

[DAB-1169]: https://retool.atlassian.net/browse/DAB-1169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ