### PR TITLE
Improve styling

### DIFF
--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -1,29 +1,49 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
-
+import styled from 'styled-components';
 import Icon from '../Icon';
 import FormElementWrapper from '../FormComponents/FormElementWrapper';
 import FormElement from '../FormComponents/FormElement';
+import { theme } from '../../theme';
+
+const FormSelectElement = styled(FormElement)`
+  color: ${props => (props.isEmpty ? theme.color_v3.type.light : 'inherit')};
+`;
 
 const Select = React.forwardRef(
   ({ id, options, placeholder, ...props }, ref) => {
+    const [isEmpty, setIsEmpty] = useState(!props.defaultValue);
+
+    const onChange = useCallback(
+      e => {
+        setIsEmpty(!e.target.value);
+        if (typeof props.onChange === 'function') props.onChange(e);
+      },
+      [props],
+    );
+
     return (
       <FormElementWrapper invalid={props.invalid} valid={props.valid}>
-        <FormElement
+        <FormSelectElement
           as='select'
           id={id}
           name={id}
           ref={ref}
           withIcon
           {...props}
+          onChange={onChange}
+          defaultValue={props.defaultValue || ''}
+          isEmpty={isEmpty}
         >
-          {placeholder && <option value=''>{placeholder}</option>}
+          <option disabled value='' hidden={!placeholder}>
+            {placeholder || ''}
+          </option>
           {options.map(({ label, value, disabled = false }) => (
             <option key={value} value={value} disabled={disabled}>
               {label}
             </option>
           ))}
-        </FormElement>
+        </FormSelectElement>
         {props.valid ? (
           <Icon icon={Icon.ICONS.IconCheck} size={Icon.SIZES.L} />
         ) : props.invalid ? (
@@ -55,6 +75,7 @@ Select.propTypes = {
   ),
   placeholder: PropTypes.string,
   valid: PropTypes.bool,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Select.defaultProps = {

--- a/src/components/Toggle/index.js
+++ b/src/components/Toggle/index.js
@@ -74,6 +74,7 @@ const Toggle = React.forwardRef(
         {(children || helper) && (
           <ToggleLabels
             className='f-Toggle-labels'
+            as='label'
             {...labelProps}
             disabled={disabled}
           >

--- a/src/components/Toggle/styles.js
+++ b/src/components/Toggle/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/macro';
 import FormElementWrapper from '../FormComponents/FormElementWrapper';
 import { theme } from '../../theme';
+import UiText from '../UiText';
 
 const styles = {
   toggle: {
@@ -93,7 +94,10 @@ export const ToggleBulletLabelOn = styled(ToggleBulletLabel)`
   visibility: ${({ isOn }) => (isOn ? 'visible' : 'hidden')};
 `;
 
-export const ToggleLabels = styled('span')`
+export const ToggleLabels = styled(UiText).attrs({
+  variant: UiText.VARIANTS.content,
+})`
+  margin: 0;
   margin-left: ${theme.space.l};
   cursor: ${({ disabled }) => disabled && 'not-allowed'};
 `;

--- a/src/styles.css
+++ b/src/styles.css
@@ -215,3 +215,7 @@ a:hover {
 img {
   max-width: 100%;
 }
+
+::placeholder {
+  color: var(--f-color-type-light);
+}


### PR DESCRIPTION
# `Toggle` component

Aligned text style of the label with other fields. 

Before:
<img width="118" alt="image" src="https://user-images.githubusercontent.com/512823/193849431-745e4e6e-2be8-4573-9e65-8fb4aec18615.png">

After:
<img width="116" alt="image" src="https://user-images.githubusercontent.com/512823/193849301-98f45578-c3c2-4a02-b28c-0307e7c22952.png">

# `Select` component

Improved styling and behaviour of the blank option/placeholder.

Before:
<img width="539" alt="image" src="https://user-images.githubusercontent.com/512823/193850090-8a32adfb-1ac4-40a0-bee5-7553df3ba16d.png">
<img width="385" alt="image" src="https://user-images.githubusercontent.com/512823/193850178-463f4b4e-c1a0-4e83-8bda-97c45f9734ef.png">

After:
<img width="407" alt="image" src="https://user-images.githubusercontent.com/512823/193850275-4b723dc8-b65e-4685-936c-588e5f842918.png">
<img width="351" alt="image" src="https://user-images.githubusercontent.com/512823/193850314-45eba935-d763-4bfe-843a-8e3116355fce.png">

There is always an empty option, and it is selected if no `defaultValue` is provided. But if no placeholder text is provided for this empty option, the option itself doesn't appear in the list. 
If a placeholder is provided, it is properly styled, and the option in the list is not selectable once another value has been selected.

# Misc.

Set the default placeholder text color to an actual color of the palette instead of the browser's default.
