### PR TITLE
fix: SidePanel calling onClose even when already closed

### DIFF
--- a/src/components/SidePanel/index.js
+++ b/src/components/SidePanel/index.js
@@ -30,6 +30,7 @@ const SidePanel = props => {
   };
 
   const handleClose = React.useCallback(() => {
+    if (!props.isOpen) return;
     document.body.style.overflow = 'initial';
     setIsOpen(false);
     props.onClose();


### PR DESCRIPTION
This PR fixes a bad behaviour of SidePanel, especially when we use several of them and different values of a state to determine which one is opened: the component called its onClose function each time isOpen was evaluated to false, even if it had not changed. 

Before:
https://user-images.githubusercontent.com/512823/202407732-9aaa1e98-112f-470a-a38b-e8864e869520.mov

After:
https://user-images.githubusercontent.com/512823/202407784-24adb493-41d8-4a94-8db7-9a9a531d0278.mov

