### PR TITLE
fix: SidePanel not reacting to external change of isOpen

### DIFF
--- a/src/components/SidePanel/index.js
+++ b/src/components/SidePanel/index.js
@@ -30,10 +30,9 @@ const SidePanel = props => {
   };
 
   const handleClose = React.useCallback(() => {
-    if (!props.isOpen) return;
     document.body.style.overflow = 'initial';
     setIsOpen(false);
-    props.onClose();
+    if (props.isOpen) props.onClose();
   }, [props]);
 
   const handleEscape = React.useCallback(


### PR DESCRIPTION
The previous fix broke the side panel rendering when the `isOpen` value is changed from the outside when the panel is visible (for exemple from the click on a button inside the panel's children). 

This video shows the panel working correctly in this situation using this fix:
https://user-images.githubusercontent.com/512823/202458028-038cde3f-12f1-415b-8d0c-b0b9748952bc.mov

